### PR TITLE
Fix login

### DIFF
--- a/Pancake/AppDelegate.swift
+++ b/Pancake/AppDelegate.swift
@@ -29,7 +29,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if SPTAuth.defaultInstance().canHandleURL(url){
             SPTAuth.defaultInstance().handleAuthCallbackWithTriggeredAuthURL(url, callback: { (error:NSError!, session: SPTSession!) -> Void in
                 if error != nil {
-                    print("AUTHENTICIFATION ERROR")
+                    print("===AUTHENTICATION ERROR===")
+                    print(error)
                     return
                 }
                 

--- a/Pancake/Info.plist
+++ b/Pancake/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Pancake/LoginViewController.swift
+++ b/Pancake/LoginViewController.swift
@@ -24,9 +24,8 @@ class LoginViewController: UIViewController {
         let userDefaults = NSUserDefaults.standardUserDefaults()
         
         if let sessionObj:AnyObject = userDefaults.objectForKey("SpotifySession") {// Session available
-            
-            // Something sounds to be wrong here. 
-
+            // print session
+            print(sessionObj)
         }else{
             loginButton.hidden = false
         }
@@ -44,8 +43,8 @@ class LoginViewController: UIViewController {
         
         auth.clientID = kClientId
         auth.redirectURL = NSURL(string:kCallbackUrl)
-        auth.tokenSwapURL = NSURL(string:kTokenSwapUrl)
-        auth.tokenRefreshURL = NSURL(string:kTokenRefreshServiceUrl)
+//        auth.tokenSwapURL = NSURL(string:kTokenSwapUrl)
+//        auth.tokenRefreshURL = NSURL(string:kTokenRefreshServiceUrl)
         auth.requestedScopes = [SPTAuthStreamingScope]
         
         let loginURL = auth.loginURL


### PR DESCRIPTION
This pull request fixes your Login issue.

* I've added a global allow for http requests in the info.plist (see app transport security for more info), you  should add an exclude domain for Spotify urls instead of keeping this setting!!
* Removed the setting of token urls (this actually fixes your issue), according to the Spotify example, you don't need this (https://developer.spotify.com/technologies/spotify-ios-sdk/tutorial/).